### PR TITLE
Implement autopopulation of videos on leaf folder click

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <Navbar @video-selected="changeClippedVideo"></Navbar>
+    <Navbar @video-selected="changeClippedVideo" @two-videos-selected="populateBothVideos"></Navbar>
     <VideoCompare ref="videoCompare"></VideoCompare>
   </div>
 </template>
@@ -23,6 +23,12 @@ export default {
   methods: {
     changeClippedVideo(src) {
       this.$refs.videoCompare.setClippedVideoSrc(src);
+    },
+    populateBothVideos(src1, src2) {
+      this.$refs.videoCompare.selectedVideo = "LEFT"
+      this.$refs.videoCompare.setClippedVideoSrc(src1);
+      this.$refs.videoCompare.selectedVideo = "RIGHT"
+      this.$refs.videoCompare.setClippedVideoSrc(src2);
     },
   },
 };

--- a/src/components/FolderItem.vue
+++ b/src/components/FolderItem.vue
@@ -9,11 +9,11 @@
         <font-awesome-icon class="tree-branch" icon="video" />
         {{ video.title }}
       </div>
-      <folder-item 
-        v-for="subFolder in folder.subFolders" 
-        :key="subFolder.id" 
-        :folder="subFolder" 
-        @video-selected="onVideoChange" 
+      <folder-item
+        v-for="subFolder in folder.subFolders"
+        :key="subFolder.id"
+        :folder="subFolder"
+        @video-selected="onVideoChange"
         @toggle-folder="onToggleFolder"
       />
     </div>
@@ -34,12 +34,21 @@ export default {
   methods: {
     toggleFolder() {
       this.$emit('toggle-folder', this.folder.id);
+
+      if (this.isLeafFolder() && !this.folder.isOpen) {
+        // If this is a leaf folder and it is being opened, emit the first two videos
+        this.$emit('two-videos-selected', this.folder.videoList[0].src, this.folder.videoList[1].src);
+      }
     },
     onVideoChange(src) {
       this.$emit('video-selected', src);
     },
     onToggleFolder(folderId) {
       this.$emit('toggle-folder', folderId);
+    },
+    isLeafFolder() {
+      // A leaf folder is a folder with no subfolders and more than one video
+      return this.folder.videoList.length > 1 && this.folder.subFolders.length === 0;
     },
   },
 };

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -10,6 +10,7 @@
         :folder="folder"
         @video-selected="onVideoChange"
         @toggle-folder="toggleScene"
+        @two-videos-selected="onTwoVideosSelected"
       />
     </div>
   </div>
@@ -43,7 +44,7 @@ export default {
 
           const filteredVideos = scene.videoList.filter(video => regex.test(video.title));
           const filteredFolders = filterScenes(scene.subFolders, regex);
-          
+
           if (match || filteredVideos.length > 0 || filteredFolders.length > 0) {
             const filteredScene = { ...scene };
             if (!match) {
@@ -142,6 +143,9 @@ export default {
   },
     onVideoChange(src) {
       this.$emit('video-selected', src);
+    },
+    onTwoVideosSelected(src1, src2) {
+      this.$emit('two-videos-selected', src1, src2);
     },
   },
 };


### PR DESCRIPTION
This PR implements a feature that auto populates the display of the videos when the user clicks on a folder if the folder satisfies two conditions:
1. It has no other subfolders
2. It has at least 2 videos contained in it. 