### PR TITLE
Prevent folder and video name overflow

### DIFF
--- a/src/components/FolderItem.vue
+++ b/src/components/FolderItem.vue
@@ -2,12 +2,12 @@
   <div class="scene-folder">
     <div class="scene-title" @click="toggleFolder">
       <font-awesome-icon class="folder-icon" :icon="folder.isOpen ? 'folder-open' : 'folder'" />
-      {{ folder.title }}
+      <div class="ellipsis">{{ folder.title }}</div>
     </div>
     <div v-if="folder.isOpen">
       <div v-for="video in folder.videoList" :key="video.id" class="video-tile" @click.stop="onVideoChange(video.src)">
         <font-awesome-icon class="tree-branch" icon="video" />
-        {{ video.title }}
+        <div class="ellipsis">{{ video.title }}</div>
       </div>
       <folder-item v-for="subFolder in folder.subFolders" :key="subFolder.id" :folder="subFolder"
         @video-selected="onVideoChange" @toggle-folder="onToggleFolder" @can-populate-videos="onCanPopulateVideos"/>
@@ -145,4 +145,10 @@ h3 {
 .tree-branch {
   margin-right: 5px;
 }
+.ellipsis {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 </style>


### PR DESCRIPTION
Fix overflows for long folder/video names. 

Going from this:
<img width="381" alt="Screenshot 2023-11-13 at 18 33 23" src="https://github.com/deeprender/video-diagnostics/assets/58387984/00e61e3d-c8d2-4de4-87f7-21667a323460">
to this:
<img width="318" alt="Screenshot 2023-11-13 at 22 01 09" src="https://github.com/deeprender/video-diagnostics/assets/58387984/9b4daae4-455b-4527-9342-4868bb6ca68a">
